### PR TITLE
Fix/workaround for a panic on autocompletion

### DIFF
--- a/autocompletecontext.go
+++ b/autocompletecontext.go
@@ -308,7 +308,7 @@ func mergeDeclsFromPackages(pkgscope *Scope, pkgs PackageImports, pcache Package
 		}
 		p := pcache[path].main
 		if p == nil {
-			break
+			continue
 		}
 		for _, d := range p.Children {
 			if ast.IsExported(d.Name) {


### PR DESCRIPTION
I was getting this stack trace from the daemon when completing on: "obj."  (minus the quotes)

```
panic: runtime error: invalid memory address or nil pointer dereference
1(runtime.panic): /home/huin/Programming/go/goroot/src/pkg/runtime/proc.c:1004
2(runtime.panicstring): /home/huin/Programming/go/goroot/src/pkg/runtime/runtime.c:92
3(runtime.sigpanic): /home/huin/Programming/go/goroot/src/pkg/runtime/linux/thread.c:291
4(main.mergeDeclsFromPackages): /home/huin/Programming/go/gocode/autocompletecontext.go:310
5(main.*AutoCompleteContext·mergeDecls): /home/huin/Programming/go/gocode/autocompletecontext.go:175
6(main.*AutoCompleteContext·updateCaches): /home/huin/Programming/go/gocode/autocompletecontext.go:169
7(main.*AutoCompleteContext·Apropos): /home/huin/Programming/go/gocode/autocompletecontext.go:209
8(main.Server_AutoComplete): /home/huin/Programming/go/gocode/server.go:82
9(main.*RPCRemote·RPCServer_AutoComplete): /home/huin/Programming/go/gocode/rpc.go:25
10(reflect.*FuncValue·Call): /home/huin/Programming/go/goroot/src/pkg/reflect/value.go:853
11(rpc.*service·call): /home/huin/Programming/go/goroot/src/pkg/rpc/server.go:342
12(runtime.goexit): /home/huin/Programming/go/goroot/src/pkg/runtime/proc.c:145
```

It appears that the "p" variable was nil in stack frame 4. Putting a check in as in the patch seems to solve the issue and return decent results to completion (was only getting "PANIC" previously).
