### PR TITLE
fix completion for variables declared in the for loop init section

### DIFF
--- a/autocompletefile.go
+++ b/autocompletefile.go
@@ -162,10 +162,10 @@ func (f *AutoCompleteFile) processStmt(stmt ast.Stmt) {
 	case *ast.RangeStmt:
 		f.processRangeStmt(t)
 	case *ast.ForStmt:
+		f.processStmt(t.Init)
 		if f.cursorIn(t.Body) {
 			f.scope, _ = AdvanceScope(f.scope)
 
-			f.processStmt(t.Init)
 			f.processBlockStmt(t.Body)
 		}
 	case *ast.SwitchStmt:


### PR DESCRIPTION
an issue was reported here https://github.com/DisposaBoy/GoSublime/issues/86

basically the issue is that autocomplete doesn't work on variables declared in the for loop's init section. I'm not 100% sure about the downsides on this change but it seems to work fine and fixes the issue
