### PR TITLE
Fix auto-complete in Emacs to auto-complete all identifiers 

### DIFF
--- a/emacs/go-autocomplete.el
+++ b/emacs/go-autocomplete.el
@@ -109,7 +109,7 @@
 
 (add-hook 'go-mode-hook '(lambda()
 			   (auto-complete-mode 1)
-			   (setq ac-sources '(ac-source-go))))
+			   (setq ac-sources (append ac-sources '(ac-source-go)))))
 
 (add-to-list 'ac-modes 'go-mode)
 


### PR DESCRIPTION
Current code was not using some ac-sources like "ac-source-words-in-same-mode-buffers"
