### PR TITLE
gocode completions should have precedence

### DIFF
--- a/emacs/go-autocomplete.el
+++ b/emacs/go-autocomplete.el
@@ -109,7 +109,7 @@
 
 (add-hook 'go-mode-hook '(lambda()
 			   (auto-complete-mode 1)
-			   (setq ac-sources (append ac-sources '(ac-source-go)))))
+			   (setq ac-sources (append '(ac-source-go) ac-sources))))
 
 (add-to-list 'ac-modes 'go-mode)
 


### PR DESCRIPTION
Last change enabled auto-completion for all identifiers but introduced a problem. The two auto-completion behaviors were in conflict (typing "fmt.P". Sometimes, auto-completion show the signatures of Print(), Printf() and Println(), but more frequently it shows all identifiers that start with 'P')

Current commit corrects this by giving priority to gocode... and problem above is solved...but there is still another problem... for example when typing "sql.P" (sql from "database/sql), because there is no exported symbol in database/sql that starts with 'P', auto-complete shows a list of identifiers in the code that start with 'P' and this is confusing and really wrong because they don't belong to the package...

I'm trying to solve this (with my limited elisp knowledge) but it's being a challenge...
