### PR TITLE
Add Package-Requires header for ELPA installations

### DIFF
--- a/emacs/go-autocomplete.el
+++ b/emacs/go-autocomplete.el
@@ -4,6 +4,7 @@
 
 ;; Author: Mikhail <tensai@cirno.in> Kuryshev
 ;; Keywords: languages
+;; Package-Requires: ((auto-complete "1.4.0"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
This commit adds a header which tells package.el that go-autocomplete depends on auto-complete.

(Background: I've added a [MELPA](http://melpa.milkbox.net/) recipe for go-autocomplete.el)
