### PR TITLE
fixed transparent popup frame

### DIFF
--- a/emacs/go-autocomplete.el
+++ b/emacs/go-autocomplete.el
@@ -122,8 +122,8 @@
 
 (ac-define-source go
   '((candidates . ac-go-candidates)
-    (candidate-face . ac-clang-candidate-face)
-    (selection-face . ac-clang-selection-face)
+    (candidate-face . ac-candidate-face)
+    (selection-face . ac-selection-face)
     (document . ac-go-document)
     (action . ac-go-action)
     (prefix . ac-go-prefix)


### PR DESCRIPTION
Popup frame colors was inherited from auto-complete-clang, which is not set as required, displayed as transparent. Made it more standart, only auto-complete package needed(as it should be) and with right colors in popup.
