### PR TITLE
Fix calculating offset position in go-autocomplete.el

### DIFF
--- a/emacs/go-autocomplete.el
+++ b/emacs/go-autocomplete.el
@@ -78,7 +78,7 @@
 			     "-f=emacs"
 			     "autocomplete"
 			     (buffer-file-name)
-			     (int-to-string (- (point) 1)))
+			     (concat "c" (int-to-string (- (point) 1))))
 	(with-current-buffer temp-buffer (buffer-string))
       (kill-buffer temp-buffer))))
 


### PR DESCRIPTION
If I am editing a file containing an unicode character autocompletion stopped working properly. This patch fixes the issue. I copied this from company-go.el.
