### PR TITLE
vim/*.bash: Be usable from outer directory and remove bash-ism

### DIFF
--- a/vim/pathogen_update.bash
+++ b/vim/pathogen_update.bash
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-mkdir -p ~/.vim/bundle/gocode/{autoload,ftplugin}
-cp "${0%/*}autoload/gocomplete.vim" ~/.vim/bundle/gocode/autoload
-cp "${0%/*}ftplugin/go.vim" ~/.vim/bundle/gocode/ftplugin

--- a/vim/pathogen_update.sh
+++ b/vim/pathogen_update.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+mkdir -p "$HOME/.vim/bundle/gocode/autoload"
+mkdir -p "$HOME/.vim/bundle/gocode/ftplugin"
+cp "${0%/*}autoload/gocomplete.vim" "$HOME/.vim/bundle/gocode/autoload"
+cp "${0%/*}ftplugin/go.vim" "$HOME/.vim/bundle/gocode/ftplugin"

--- a/vim/update.bash
+++ b/vim/update.bash
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-mkdir -p ~/.vim/{autoload,ftplugin}
-cp "${0%/*}/autoload/gocomplete.vim" ~/.vim/autoload
-cp "${0%/*}/ftplugin/go.vim" ~/.vim/ftplugin

--- a/vim/update.sh
+++ b/vim/update.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+mkdir -p "$HOME/.vim/autoload"
+mkdir -p "$HOME/.vim/ftplugin"
+cp "${0%/*}/autoload/gocomplete.vim" "$HOME/.vim/autoload"
+cp "${0%/*}/ftplugin/go.vim" "$HOME/.vim/ftplugin"


### PR DESCRIPTION
The first patch makes vim/*.bash usable (runnable) from outer directory.

The second one renaems vim/_.bash to vim/_.sh and removes bash-ism for
POSIX (non-bash) shells.
