### PR TITLE
Support double byte character set

### DIFF
--- a/vim/autoload/gocomplete.vim
+++ b/vim/autoload/gocomplete.vim
@@ -5,6 +5,9 @@ let g:loaded_gocode = 1
 
 fu! s:gocodeCurrentBuffer()
 	let buf = getline(1, '$')
+	if &encoding != 'utf-8'
+		let buf = map(buf, 'iconv(v:val, &encoding, "utf-8")')
+	endif
 	if &l:fileformat == 'dos'
 		" XXX: line2byte() depend on 'fileformat' option.
 		" so if fileformat is 'dos', 'buf' must include '\r'.
@@ -40,6 +43,9 @@ fu! s:gocodeCommand(cmd, preargs, args)
 	if v:shell_error != 0
 		return "[\"0\", []]"
 	else
+		if &encoding != 'utf-8'
+			let result = iconv(result, 'utf-8', &encoding)
+		endif
 		return result
 	endif
 endf
@@ -49,6 +55,12 @@ fu! s:gocodeCurrentBufferOpt(filename)
 endf
 
 fu! s:gocodeCursor()
+	if &encoding != 'utf-8'
+		let c = col('.')
+		let buf = line('.') == 1 ? "" : (join(getline(1, line('.')-1), "\n") . "\n")
+		let buf .= c < 1 ? "" : getline('.')[:c-1]
+		return printf('%d', len(iconv(buf, &encoding, "utf-8")))
+	endif
 	return printf('%d', line2byte(line('.')) + (col('.')-2))
 endf
 


### PR DESCRIPTION
In japanese, many people are editing utf-8 file with cp932 encoding on windows.
(There is some people using non-utf-8 encoding on unix also)
And line2byte depend on fileencoding(i.e. utf-8). So completion doesn't work.
Below is a patch. Please check and include.
