### PR TITLE
Added missing slashes to pathogen_update.sh script

### DIFF
--- a/vim/pathogen_update.sh
+++ b/vim/pathogen_update.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 mkdir -p "$HOME/.vim/bundle/gocode/autoload"
 mkdir -p "$HOME/.vim/bundle/gocode/ftplugin"
-cp "${0%/*}autoload/gocomplete.vim" "$HOME/.vim/bundle/gocode/autoload"
-cp "${0%/*}ftplugin/go.vim" "$HOME/.vim/bundle/gocode/ftplugin"
+cp "${0%/*}/autoload/gocomplete.vim" "$HOME/.vim/bundle/gocode/autoload"
+cp "${0%/*}/ftplugin/go.vim" "$HOME/.vim/bundle/gocode/ftplugin"


### PR DESCRIPTION
Fixed pathogen_update.sh script works for me on OS X. But I think that it was broken for everyone before, not just me.
