### PR TITLE
fix byte compiling warnings

### DIFF
--- a/emacs/go-autocomplete.el
+++ b/emacs/go-autocomplete.el
@@ -85,8 +85,8 @@
 (defun ac-go-format-autocomplete (buffer-contents)
   (sort
    (split-string buffer-contents "\n" t)
-   '(lambda (a b) (string< (downcase a)
-			   (downcase b)))))
+   (lambda (a b) (string< (downcase a)
+                          (downcase b)))))
 
 (defun ac-go-get-candidates (strings)
   (let ((prop (lambda (entry)


### PR DESCRIPTION
I got following warning at byte compiling `go-autocomplete.el`.

```
Compiling file /home/syohei/tmp/gomi/go-autocomplete.el at Mon Jun 17 22:15:10 2013
Entering directory `/home/syohei/tmp/gomi/'
go-autocomplete.el:85:1:Warning: (lambda (a b) ...) quoted with ' rather than
    with #'
```

lambda expression does not be needed quote.
Please see this patch.
