### PR TITLE
Update pathogen_update.sh with recent changes

### DIFF
--- a/vim/pathogen_update.sh
+++ b/vim/pathogen_update.sh
@@ -2,4 +2,4 @@
 mkdir -p "$HOME/.vim/bundle/gocode/autoload"
 mkdir -p "$HOME/.vim/bundle/gocode/ftplugin"
 cp "${0%/*}/autoload/gocomplete.vim" "$HOME/.vim/bundle/gocode/autoload"
-cp "${0%/*}/ftplugin/go.vim" "$HOME/.vim/bundle/gocode/ftplugin"
+cp "${0%/*}/ftplugin/go/gocomplete.vim" "$HOME/.vim/bundle/gocode/ftplugin"


### PR DESCRIPTION
16be5f moved go.vim to go/gocomplete.vim, and update update.sh, but
pathogen_update.sh is still trying to cp the old path which no longer
exists.
