### PR TITLE
Fix filetype plugin install location for pathogen

### DIFF
--- a/vim/pathogen_update.sh
+++ b/vim/pathogen_update.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 mkdir -p "$HOME/.vim/bundle/gocode/autoload"
-mkdir -p "$HOME/.vim/bundle/gocode/ftplugin"
+mkdir -p "$HOME/.vim/bundle/gocode/ftplugin/go"
 cp "${0%/*}/autoload/gocomplete.vim" "$HOME/.vim/bundle/gocode/autoload"
-cp "${0%/*}/ftplugin/go/gocomplete.vim" "$HOME/.vim/bundle/gocode/ftplugin"
+cp "${0%/*}/ftplugin/go/gocomplete.vim" "$HOME/.vim/bundle/gocode/ftplugin/go"


### PR DESCRIPTION
I had to add the gocomplete.vim to the .vim/bundle/gocode/ftplugin/go directory to get this to work. This was not necessary back when it was named go.vim. 

Either way, this fix works for me.
