### PR TITLE
[emacs] Add Package-Requires header for ELPA installations

### DIFF
--- a/emacs-company/company-go.el
+++ b/emacs-company/company-go.el
@@ -4,6 +4,7 @@
 
 ;; Author: nsf <no.smile.face@gmail.com>
 ;; Keywords: languages
+;; Package-Requires: ((company "0.6.12"))
 
 ;; No license, this code is under public domain, do whatever you want.
 


### PR DESCRIPTION
This header declares a dependency on company, so that installation of company-go via Emacs package archives will work robustly.

Background: we're adding `company-go` to [MELPA](http://melpa.milkbox.net/): https://github.com/milkypostman/melpa/pull/1181

Cheers,

-Steve
