### PR TITLE
Fix tests which start failing from go 1.2

### DIFF
--- a/_testing/test.0011/out.expected
+++ b/_testing/test.0011/out.expected
@@ -1,4 +1,4 @@
-Found 56 candidates:
+Found 59 candidates:
   func Addr() reflect.Value
   func Bool() bool
   func Bytes() []byte
@@ -10,6 +10,7 @@ Found 56 candidates:
   func Cap() int
   func Close()
   func Complex() complex128
+  func Convert(t reflect.Type) reflect.Value
   func Elem() reflect.Value
   func Field(i int) reflect.Value
   func FieldByIndex(index []int) reflect.Value
@@ -40,6 +41,7 @@ Found 56 candidates:
   func Set(x reflect.Value)
   func SetBool(x bool)
   func SetBytes(x []byte)
+  func SetCap(n int)
   func SetComplex(x complex128)
   func SetFloat(x float64)
   func SetInt(x int64)
@@ -48,7 +50,8 @@ Found 56 candidates:
   func SetPointer(x unsafe.Pointer)
   func SetString(x string)
   func SetUint(x uint64)
-  func Slice(beg int, end int) reflect.Value
+  func Slice(i int, j int) reflect.Value
+  func Slice3(i int, j int, k int) reflect.Value
   func String() string
   func TryRecv() (x reflect.Value, ok bool)
   func TrySend(x reflect.Value) bool

--- a/_testing/test.0036/out.expected
+++ b/_testing/test.0036/out.expected
@@ -1,6 +1,7 @@
-Found 18 candidates:
+Found 20 candidates:
   func Close() error
   func DWARF() (*dwarf.Data, error)
+  func DynString(tag elf.DynTag) ([]string, error)
   func ImportedLibraries() ([]string, error)
   func ImportedSymbols() ([]elf.ImportedSymbol, error)
   func Section(name string) *elf.Section
@@ -10,6 +11,7 @@ Found 18 candidates:
   var ByteOrder binary.ByteOrder
   var Class elf.Class
   var Data elf.Data
+  var Entry uint64
   var FileHeader elf.FileHeader
   var Machine elf.Machine
   var OSABI elf.OSABI


### PR DESCRIPTION
Some tests are failing because of API change in go 1.2.
