### PR TITLE
Close gocode daemon at emacs exit

### DIFF
--- a/emacs/go-autocomplete.el
+++ b/emacs/go-autocomplete.el
@@ -38,6 +38,15 @@
   (require 'cl)
   (require 'auto-complete))
 
+;; Close gocode daemon at exit unless it was already running
+(eval-after-load "go-mode"
+  '(progn
+     (let* ((user (or (getenv "USER") "all"))
+            (sock (format (concat temporary-file-directory "gocode-daemon.%s") user)))
+       (unless (file-exists-p sock)
+         (add-hook 'kill-emacs-hook #'(lambda ()
+                                        (call-process "gocode" nil nil nil "close")))))))
+
 ;(defvar go-reserved-keywords
 ;  '("break" "case" "chan" "const" "continue" "default" "defer" "else"
 ;    "fallthrough" "for" "func" "go" "goto" "if" "import" "interface"


### PR DESCRIPTION
Register a kill-emacs-hook to run 'gocode close' when emacs exits.

The hook is not registered if the daemon unix socket already exists,
assumes gocode daemon was running before go-mode was loaded.
