### PR TITLE
Use company-grab-word instead of a regex

### DIFF
--- a/emacs-company/company-go.el
+++ b/emacs-company/company-go.el
@@ -49,7 +49,7 @@
 
 (defun company-go (command &optional arg &rest ignored)
   (case command
-    (prefix (company-grab "\\.\\(\\w*\\)" 1))
+    (prefix (company-grab-word))
     (candidates (company-go--candidates))
     (meta (get-text-property 0 'meta arg))
     (sorted t)))


### PR DESCRIPTION
The regular expression being used here doesn't always give desirable results.

Example:

``` go
thing := OtherThing()
thi // won't autocomplete to `thing`

type Foo struct {
   Bar string `bson:"foo"`
}

foo := Foo{}
foo.B // will autocomplete to `Bar`
```

Because it has a hard `.` anchor in the `prefix` case, it will only ever match methods or attributes and never local variables, even though `gocode` itself would complete both cases fine. Changing it to `company-grab-word` satisfies both cases because we get a matching prefix (as long as you satisfy `company-minimum-prefix-length`).
