### PR TITLE
[emacs-company] Add autoload cookie

### DIFF
--- a/emacs-company/company-go.el
+++ b/emacs-company/company-go.el
@@ -47,6 +47,7 @@
 (defun company-go--candidates ()
   (company-go--get-candidates (split-string (company-go--invoke-autocomplete) "\n" t)))
 
+;;;###autoload
 (defun company-go (command &optional arg &rest ignored)
   (case command
     (prefix (company-grab-word))


### PR DESCRIPTION
This commit ensures that users who have installed `company-go` from MELPA will be able to use the code without explicitly requiring the library first.
