### PR TITLE
emacs-company: Support annotation

### DIFF
--- a/emacs-company/company-go.el
+++ b/emacs-company/company-go.el
@@ -15,6 +15,15 @@
   (require 'company)
   (require 'go-mode))
 
+(defgroup company-go nil
+  "Completion back-end for Go."
+  :group 'company)
+
+(defcustom company-go-show-annotation nil
+  "Show an annotation inline with the candidate."
+  :group 'company-go
+  :type 'boolean)
+
 (defun company-go--invoke-autocomplete ()
   (let ((temp-buffer (generate-new-buffer "*gocode*")))
     (prog2
@@ -104,7 +113,9 @@
     (prefix (company-grab-word))
     (candidates (company-go--candidates))
     (meta (get-text-property 0 'meta arg))
-    (annotation (get-text-property 0 'meta arg))
+    (annotation
+     (when company-go-show-annotation
+       (get-text-property 0 'meta arg)))
     (location (company-go--location arg))
     (sorted t)))
 


### PR DESCRIPTION
This commit enable `company-go` to show annotation like this:

![140221-0001](https://f.cloud.github.com/assets/3079551/2229552/fa91b296-9af0-11e3-922c-a29673c8a8be.png)
