### PR TITLE
Add a fallback check -- if pkg/OS_ARCH for the lib-path variable works, ...

### DIFF
--- a/declcache.go
+++ b/declcache.go
@@ -226,6 +226,12 @@ func find_global_file(imp string, env *gocode_env) (string, bool) {
 			if file_exists(pkg_path) {
 				return pkg_path, true
 			}
+			// Also check the relevant pkg/OS_ARCH dir for the libpath, if provided.
+			pkgdir := fmt.Sprintf("%s_%s", env.GOOS, env.GOARCH)
+			pkg_path = filepath.Join(p, "pkg", pkgdir, pkgfile)
+			if file_exists(pkg_path) {
+				return pkg_path, true
+			}
 		}
 	}
 


### PR DESCRIPTION
...then use that.

A relatively minor change, but one that kind of surprised me. If I've set lib-path with `gocode set`, it expects the exact library path, which is not usually what you want/provide. It's easier to give it the root and let it figure out pkg/OS_ARCH from that.

So, why not both? This patch shouldn't break anybody and should fix some people (like myself) who set GOPATH in a virtualenv-sort-of-way.
