### PR TITLE
Fix E704 issue

### DIFF
--- a/vim/autoload/gocomplete.vim
+++ b/vim/autoload/gocomplete.vim
@@ -18,10 +18,10 @@ fu! s:gocodeCurrentBuffer()
 	return file
 endf
 
-let s:vim_system = get(g:, 'gocomplete#system_function', function('system'))
+let s:vim_system = get(g:, 'gocomplete#system_function', 'system')
 
 fu! s:system(str, ...)
-	return (a:0 == 0 ? s:vim_system(a:str) : s:vim_system(a:str, join(a:000)))
+	return call(s:vim_system, [a:str] + a:000)
 endf
 
 fu! s:gocodeShellescape(arg)


### PR DESCRIPTION
On windows, when want to replace system function to [vimproc](https://github.com/Shougo/vimproc), it can set the function to `gocomplete#system_function`. But, sorry, I mistaken to design.
It can't set system function name to lower-letter-variables. `gocomplete#system_function` should be set as name of function instead of function reference.
