### PR TITLE
Allow emacs to exit when gocode binary cannot be found

### DIFF
--- a/emacs/go-autocomplete.el
+++ b/emacs/go-autocomplete.el
@@ -45,7 +45,8 @@
             (sock (format (concat temporary-file-directory "gocode-daemon.%s") user)))
        (unless (file-exists-p sock)
          (add-hook 'kill-emacs-hook #'(lambda ()
-                                        (call-process "gocode" nil nil nil "close")))))))
+                                        (ignore-errors
+                                          (call-process "gocode" nil nil nil "close"))))))))
 
 ;(defvar go-reserved-keywords
 ;  '("break" "case" "chan" "const" "continue" "default" "defer" "else"


### PR DESCRIPTION
This fixes #201 by ignoring the errors from attempting to close gocode.
