### PR TITLE
Off-by-one error in gocomplete.vim?

### DIFF
--- a/vim/autoload/gocomplete.vim
+++ b/vim/autoload/gocomplete.vim
@@ -63,7 +63,7 @@ fu! s:gocodeCursor()
 		let buf .= c == 1 ? "" : getline('.')[:c-2]
 		return printf('%d', len(iconv(buf, &encoding, "utf-8")))
 	endif
-	return printf('%d', line2byte(line('.')) + (col('.')-2))
+	return printf('%d', line2byte(line('.')) + (col('.')-1))
 endf
 
 fu! s:gocodeAutocomplete()


### PR DESCRIPTION
When I autocomplete e.g.

``` go
package main
import "net/http"
func init() {
  http.<-
}
```

I currently get the single autocompletion entry "package http". If I type a second '.' and autocomplete again, I get the proper contents of the http package. The proposed change fixes this behavior for me... Am I doing something wrong somehow, or is this actually broken?
