### PR TITLE
Disable profiler by default

### DIFF
--- a/gocode.go
+++ b/gocode.go
@@ -17,7 +17,7 @@ var (
 	g_sock      = create_sock_flag("sock", "socket type (unix | tcp)")
 	g_addr      = flag.String("addr", "localhost:37373", "address for tcp socket")
 	g_debug     = flag.Bool("debug", false, "enable server-side debug mode")
-	g_profile   = flag.Int("profile", 6060, "port on which to expose profiling information for pprof; 0 to disable profiling")
+	g_profile   = flag.Int("profile", 0, "port on which to expose profiling information for pprof; 0 to disable profiling")
 )
 
 func get_socket_filename() string {


### PR DESCRIPTION
Require setting the `profile` flag to the port on which the profiler should listen; default will be 0, which means that the profiler is disabled.

Fixes #228.
