### PR TITLE
Improve prefix function in company-go

### DIFF
--- a/emacs-company/README.md
+++ b/emacs-company/README.md
@@ -1,5 +1,6 @@
 # Company-go
-Company-go is an alternative emacs plugin for autocompletion. Is uses [company-mode](http://company-mode.github.io). Completion will start automatically after you type a few letters.
+Company-go is an alternative emacs plugin for autocompletion. Is uses [company-mode](http://company-mode.github.io).
+Completion will start automatically whenever the current symbol is preceded by a `.`, or after you type `company-minimum-prefix-length` letters.
 
 ## Setup
 Install `company` and `company-go`.
@@ -15,7 +16,6 @@ Add the following to your emacs-config:
 
 ```lisp
 (setq company-tooltip-limit 20)                      ; bigger popup window
-(setq company-minimum-prefix-length 0)               ; autocomplete right after '.'
 (setq company-idle-delay .3)                         ; decrease delay before autocompletion popup shows
 (setq company-echo-delay 0)                          ; remove annoying blinking
 (setq company-begin-commands '(self-insert-command)) ; start autocompletion only after typing

--- a/emacs-company/company-go.el
+++ b/emacs-company/company-go.el
@@ -4,7 +4,7 @@
 
 ;; Author: nsf <no.smile.face@gmail.com>
 ;; Keywords: languages
-;; Package-Requires: ((company "0.6.12"))
+;; Package-Requires: ((company "0.8.0"))
 
 ;; No license, this code is under public domain, do whatever you want.
 
@@ -31,6 +31,12 @@
 
 (defcustom company-go-show-annotation nil
   "Show an annotation inline with the candidate."
+  :group 'company-go
+  :type 'boolean)
+
+(defcustom company-go-begin-after-member-access t
+  "When non-nil, automatic completion will start whenever the current
+symbol is preceded by a \".\", ignoring `company-minimum-prefix-length'."
   :group 'company-go
   :type 'boolean)
 
@@ -93,6 +99,13 @@
         (kill-buffer temp-buffer)
         (delete-file temp)))))
 
+(defun company-go--prefix ()
+  "Returns the symbol to complete. Also, if point is on a dot,
+triggers a completion immediately."
+  (if company-go-begin-after-member-access
+      (company-grab-symbol-cons "\\." 1)
+    (company-grab-symbol)))
+
 (defun company-go--godef-jump (point)
   (condition-case nil
       (let ((file (car (godef--call point))))
@@ -120,7 +133,9 @@
 ;;;###autoload
 (defun company-go (command &optional arg &rest ignored)
   (case command
-    (prefix (company-grab-word))
+    (prefix (and (derived-mode-p 'go-mode)
+                 (not (company-in-string-or-comment))
+                 (or (company-go--prefix) 'stop)))
     (candidates (company-go--candidates))
     (meta (get-text-property 0 'meta arg))
     (annotation


### PR DESCRIPTION
Rather using company-minimum-prefix-length 0, change the prefix function
to autocomplete right after '.', regardless of company-minimum-prefix-length.
