### PR TITLE
Add dummy return statements

### DIFF
--- a/cursorcontext.go
+++ b/cursorcontext.go
@@ -30,6 +30,7 @@ func (i token_item) Literal() string {
 	} else {
 		return i.tok.String()
 	}
+	return ""
 }
 
 func (this *token_iterator) token() token_item {
@@ -288,4 +289,5 @@ func (c *auto_complete_context) deduce_cursor_type_pkg(file []byte, cursor int) 
 		t, scope, _ := infer_type(expr, c.current.scope, -1)
 		return t, lookup_pkg(get_type_path(t), scope), t != nil
 	}
+	return nil, "", false
 }


### PR DESCRIPTION
Functions defined at Line#27 and Line#274 should add dummy return statements to be compatible for Go1.0.2 or former. Otherwise it should detect the version of go language and throw errors.
