### PR TITLE
Fix slice indexing in cursorcontext

### DIFF
--- a/cursorcontext.go
+++ b/cursorcontext.go
@@ -227,6 +227,12 @@ func (c *auto_complete_context) deduce_cursor_context(file []byte, cursor int) (
 			// Calculate the offset of the cursor position within the identifier.
 			// For instance, if we are 'ab#c', we want partial_len = 2 and partial = ab.
 			partial_len := cursor - tok.off
+			// Cursor may be past the end of the literal if there are whitespaces after
+			// the identifier, so we bring it back inside the appropriate limits if
+			// needed.
+			if partial_len > len(tok.Literal()) {
+				partial_len = len(tok.Literal())
+			}
 			partial = tok.Literal()[0:partial_len]
 		} else {
 			// Do not try to truncate if it is not an identifier.


### PR DESCRIPTION
Fixes a corner case in which if the identifier is followed by a
whitespace and the cursor is on the whitespace, the code would try to
access a slice past its boundaries:

```
panic: runtime error: slice bounds out of range
1(runtime.panic): /usr/lib/go/src/pkg/runtime/panic.c:248
2(runtime.panicstring): /usr/lib/go/src/pkg/runtime/panic.c:482
3(runtime.panicslice): /usr/lib/go/src/pkg/runtime/panic.c:439
4(main.(*auto_complete_context).deduce_cursor_context):
/home/tzn/src/go/src/github.com/nsf/gocode/cursorcontext.go:230
5(main.(*auto_complete_context).apropos):
/home/tzn/src/go/src/github.com/nsf/gocode/autocompletecontext.go:253
6(main.server_auto_complete):
/home/tzn/src/go/src/github.com/nsf/gocode/server.go:145
7(main.(*RPC).RPC_auto_complete):
/home/tzn/src/go/src/github.com/nsf/gocode/rpc.go:26
8(runtime.call64): /usr/lib/go/src/pkg/runtime/asm_amd64.s:340
9(reflect.Value.call): /usr/lib/go/src/pkg/reflect/value.go:474
10(reflect.Value.Call): /usr/lib/go/src/pkg/reflect/value.go:345
11(net/rpc.(*service).call): /usr/lib/go/src/pkg/net/rpc/server.go:381
12(runtime.goexit): /usr/lib/go/src/pkg/runtime/proc.c:1394
```
