### PR TITLE
One weird trick to speed up your imports.

### DIFF
--- a/declcache.go
+++ b/declcache.go
@@ -257,7 +257,7 @@ func find_global_file(imp string, context build.Context) (string, bool) {
 		return "unsafe", true
 	}
 
-	p, err := context.Import(imp, "", build.AllowBinary)
+	p, err := context.Import(imp, "", build.AllowBinary|build.FindOnly)
 	if err == nil {
 		if g_config.Autobuild {
 			autobuild(p)


### PR DESCRIPTION
Setting the `build.FindOnly` flag when calling `context.Import`
drastically speeds up parsing, especially when accessing remove file
systems (e.g.  nfs). Tests are still running and everything seems fine
so far, hopefully nothing relies on anything other than `p.PkgObj`, so
we should be fine.
