### PR TITLE
[emacs] Missing autocomplete configuration default

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ In order to install emacs script, you need to fulfill the following steps:
 
  		(require 'go-autocomplete)
 		(require 'auto-complete-config)
+		(ac-config-default)
 
 Also, there is an alternative plugin for emacs using company-mode. See `emacs-company/README` for installation instructions.
 


### PR DESCRIPTION
Seems that you've missed to insert, in the lines to add to the file ".emacs", the line: (ac-config-default)

Without this, on my emacs, I'm unable to use gocode.

I hope that this will be useful.