### PR TITLE
Improvements for emacs mode.

### DIFF
--- a/emacs/go-autocomplete.el
+++ b/emacs/go-autocomplete.el
@@ -111,10 +111,12 @@
 
 (defun ac-go-get-candidates (strings)
   (let ((prop (lambda (entry)
-		(let ((name (nth 0 entry))
-		      (summary (nth 1 entry)))
+		(let* ((name (nth 0 entry))
+		       (summary (nth 1 entry))
+		       (symbol (substring summary 0 1)))
 		  (propertize name
-			      'summary summary))))
+			      'summary summary
+			      'symbol symbol))))
 	(split (lambda (strings)
 		 (mapcar (lambda (str)
 			   (split-string str ",," t))
@@ -189,8 +191,7 @@
     (action . ac-go-action)
     (prefix . ac-go-prefix)
     (requires . 0)
-    (cache)
-    (symbol . "g")))
+    (cache)))
 
 (add-to-list 'ac-modes 'go-mode)
 

--- a/formatters.go
+++ b/formatters.go
@@ -103,9 +103,14 @@ type emacs_formatter struct{}
 
 func (*emacs_formatter) write_candidates(candidates []candidate, num int) {
 	for _, c := range candidates {
-		hint := c.Class.String() + " " + c.Type
-		if c.Class == decl_func {
+		var hint string
+		switch {
+		case c.Class == decl_func:
 			hint = c.Type
+		case c.Type == "":
+			hint = c.Class.String()
+		default:
+			hint = c.Class.String() + " " + c.Type
 		}
 		fmt.Printf("%s,,%s\n", c.Name, hint)
 	}


### PR DESCRIPTION
Derive symbols for auto-complete from type signatures (actually takes 1st letter from summary field, so ``type struct`` becomes ``t``, ``func (…`` becomes ``f``, ``const`` becomes ``c``, etc.).

And fixes trailing whitespace in summary field, constant's summary field have one. Probably bug in gocode daemon.