### PR TITLE
Add gocode.exe to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.a
 *.out
 gocode
+gocode.exe
 goremote
 gocodetest
 *.swp


### PR DESCRIPTION
When building on Windows, `gocode` executable is not ignored cause of the `.exe` extension.