### PR TITLE
Improve for panic case

### DIFF
--- a/emacs-company/company-go.el
+++ b/emacs-company/company-go.el
@@ -83,7 +83,10 @@ symbol is preceded by a \".\", ignoring `company-minimum-prefix-length'."
               (propertize (nth 1 candidate) 'meta (company-go--format-meta candidate)))) strings))
 
 (defun company-go--candidates ()
-  (company-go--get-candidates (split-string (company-go--invoke-autocomplete) "\n" t)))
+  (let ((candidates (company-go--get-candidates (split-string (company-go--invoke-autocomplete) "\n" t))))
+    (if (equal candidates '("PANIC"))
+        (error "GOCODE PANIC: Please check your code by \"go build\"")
+      candidates)))
 
 (defun company-go--location (arg)
   (when (require 'go-mode nil t)

--- a/emacs/go-autocomplete.el
+++ b/emacs/go-autocomplete.el
@@ -175,7 +175,13 @@
         nil)))
 
 (defun ac-go-candidates ()
-  (ac-go-get-candidates (ac-go-format-autocomplete (ac-go-invoke-autocomplete))))
+  (let ((candidates (ac-go-get-candidates
+                     (ac-go-format-autocomplete (ac-go-invoke-autocomplete)))))
+    (if (equal candidates '("PANIC"))
+        (progn
+          (message "GOCODE PANIC: Please check your code by \"go build\"")
+          nil)
+      candidates)))
 
 (defun ac-go-prefix ()
   (or (ac-prefix-symbol)


### PR DESCRIPTION
- Show message when gocode panics
- Don't complete "PANIC" word

This is related to #298.