### PR TITLE
Refactoring elisps

### DIFF
--- a/emacs-company/company-go.el
+++ b/emacs-company/company-go.el
@@ -4,7 +4,7 @@
 
 ;; Author: nsf <no.smile.face@gmail.com>
 ;; Keywords: languages
-;; Package-Requires: ((company "0.8.0"))
+;; Package-Requires: ((company "0.8.0") (go-mode "1.0.0"))
 
 ;; No license, this code is under public domain, do whatever you want.
 
@@ -13,9 +13,10 @@
 (require 'company-template)
 
 (eval-when-compile
-  (require 'cl)
-  (require 'company)
-  (require 'go-mode))
+  (require 'cl))
+
+(require 'go-mode)
+(require 'company)
 
 ;; Close gocode daemon at exit unless it was already running
 (eval-after-load "go-mode"

--- a/emacs/go-autocomplete.el
+++ b/emacs/go-autocomplete.el
@@ -35,8 +35,11 @@
 ;;; Code:
 
 (eval-when-compile
-  (require 'cl)
-  (require 'auto-complete))
+  (require 'cl))
+
+(require 'auto-complete)
+
+(declare-function yas-expand-snippet "yasnippet")
 
 (defgroup go-autocomplete nil
   "auto-complete for go language."
@@ -126,10 +129,10 @@
 (defun ac-go-action ()
   (let ((item (cdr ac-last-completion)))
     (when (stringp item)
-      (setq symbol (get-text-property 0 'summary item))
-      (message "%s" symbol)
-      (when (and (featurep 'yasnippet) ac-go-expand-arguments-into-snippets)
-        (ac-go-insert-yas-snippet-string symbol)))))
+      (let ((symbol (get-text-property 0 'summary item)))
+        (message "%s" symbol)
+        (when (and (featurep 'yasnippet) ac-go-expand-arguments-into-snippets)
+          (ac-go-insert-yas-snippet-string symbol))))))
 
 (defun ac-go-insert-yas-snippet-string (s)
   (let ((ret "") (pos (point)) match-res match args)


### PR DESCRIPTION
There are many byte-compile warnings as below. This change fixes almost all of them.

### go-autocomplete
```
In ac-go-action:
go-autocomplete.el:131:21:Warning: assignment to free variable ‘symbol’
go-autocomplete.el:133:42:Warning: reference to free variable ‘symbol’

In end of data:
go-autocomplete.el:210:1:Warning: the function ‘yas-expand-snippet’ is not
    known to be defined.
```

#### company-go

```
company-go.el:29:57:Warning: reference to free variable
    ‘company-go-gocode-command’

In end of data:
company-go.el:208:1:Warning: the following functions might not be defined at runtime:
    company-grab-symbol-cons, company-grab-symbol, godef--call,
    go--string-prefix-p, go--goto-line, company-grab-word,
    company-in-string-or-comment
```
