### PR TITLE
Revert "Register company-go with company-backends"

### DIFF
--- a/emacs-company/company-go.el
+++ b/emacs-company/company-go.el
@@ -203,6 +203,5 @@ triggers a completion immediately."
        (company-go--insert-arguments
         (get-text-property 0 'meta arg))))))
 
-(add-to-list 'company-backends 'company-go)
 (provide 'company-go)
 ;;; company-go.el ends here


### PR DESCRIPTION
This reverts commit 6f18981971171520cc9ea522837916987187508f.

This change caused issues with some company setups. Users should
configure the backend in init scripts.