### PR TITLE
[WIP] import declaration autocomplete

### DIFF
--- a/decl.go
+++ b/decl.go
@@ -20,6 +20,7 @@ const (
 	// these are in a sorted order
 	decl_const
 	decl_func
+	decl_import
 	decl_package
 	decl_type
 	decl_var
@@ -37,6 +38,8 @@ func (this decl_class) String() string {
 		return "const"
 	case decl_func:
 		return "func"
+	case decl_import:
+		return "import"
 	case decl_package:
 		return "package"
 	case decl_type:

--- a/declcache.go
+++ b/declcache.go
@@ -198,7 +198,7 @@ func autobuild(p *build.Package) error {
 		return build_package(p)
 	}
 	pt := ps.ModTime()
-	fs, err := readdir(p.Dir)
+	fs, err := readdir_lstat(p.Dir)
 	if err != nil {
 		return err
 	}

--- a/utils.go
+++ b/utils.go
@@ -14,7 +14,7 @@ import (
 )
 
 // our own readdir, which skips the files it cannot lstat
-func readdir(name string) ([]os.FileInfo, error) {
+func readdir_lstat(name string) ([]os.FileInfo, error) {
 	f, err := os.Open(name)
 	if err != nil {
 		return nil, err
@@ -35,6 +35,20 @@ func readdir(name string) ([]os.FileInfo, error) {
 		out = append(out, s)
 	}
 	return out, nil
+}
+
+// our other readdir function, only opens and reads
+func readdir(dirname string) []os.FileInfo {
+	f, err := os.Open(dirname)
+	if err != nil {
+		return nil
+	}
+	fi, err := f.Readdir(-1)
+	f.Close()
+	if err != nil {
+		panic(err)
+	}
+	return fi
 }
 
 // returns truncated 'data' and amount of bytes skipped (for cursor pos adjustment)


### PR DESCRIPTION
This closes issue #257. Work in progress right now.

Detection of being inside an import statement is done. Here is a testing file.

```go
package main

import "fmt"

import f "fmt"

import . "fmt"

import (
	"fmt"
)

import (
	"fmt"
	"log"
)

import (
	f "fmt"
	l "log"
)

import (
	. "fmt"
	l "log"
)

import (
	"fmt"; "log"
)

import (
	. "fmt"; l "log"
)

import _ "fmt"

import (
  "io/
)
```

I just need to take cc.partial and return all import paths that match.