### PR TITLE
Improve panic message to print offending/bad package

### DIFF
--- a/package.go
+++ b/package.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"go/ast"
 	"os"
 	"strings"
@@ -96,7 +97,7 @@ func (m *package_file_cache) process_package_data(data []byte) {
 	// find import section
 	i := bytes.Index(data, []byte{'\n', '$', '$'})
 	if i == -1 {
-		panic("Can't find the import section in the package file")
+		panic(fmt.Sprintf("Can't find the import section in the package file %s", m.name))
 	}
 	data = data[i+len("\n$$"):]
 


### PR DESCRIPTION
Was a corrupt .a package file - without the enhanced printing of the package name, I was stuck trying to figure out why all autocompletion requests just returned panic.