### PR TITLE
package_bin: Fix callback arg to package path instead of alias name

### DIFF
--- a/package_bin.go
+++ b/package_bin.go
@@ -293,7 +293,7 @@ func (p *gc_bin_parser) typ(parent aliasedPkgName) ast.Expr {
 		t0 := p.typ(parent)
 		tdecl.Specs[0].(*ast.TypeSpec).Type = t0
 
-		p.callback(parent.alias, tdecl)
+		p.callback(parent.path, tdecl)
 
 		// interfaces have no methods
 		if _, ok := t0.(*ast.InterfaceType); ok {
@@ -314,7 +314,7 @@ func (p *gc_bin_parser) typ(parent aliasedPkgName) ast.Expr {
 			results := p.paramList()
 
 			strip_method_receiver(recv)
-			p.callback(parent.alias, &ast.FuncDecl{
+			p.callback(parent.path, &ast.FuncDecl{
 				Recv: recv,
 				Name: ast.NewIdent(name),
 				Type: &ast.FuncType{Params: params, Results: results},


### PR DESCRIPTION
Fix callback arg to package path.
This fix will resolve that issue.
https://github.com/nsf/gocode/issues/352

I don't know whether this pull request is correct. If the wrong fix, please point out.

Also, there might be a problem because I tested only a little.
but `_testing/all.bash` test is all passed.

- `p.callback(parent.path, tdecl)`
 - for `decl_var`.
- `p.callback(parent.path, &ast.FuncDecl{`
 - for `decl_func`.

---

Test sample:

```go
package main

import (
	"go/parser"
	"go/token"
	"io/ioutil"
	"log"
)

func main() {
	buf, err := ioutil.ReadFile("hello.go")
	if err != nil {
		log.Fatal(err)
	}

	fset := token.NewFileSet()
	f, err := parser.ParseFile(fset, "hello.go", buf, parser.Mode(0))
	if err != nil {
		log.Fatal(err)
	}

	f.
}
```
byte offset: `348`
cmd: `gocode --in ./parser.go autocomplete 348`

===

```go
package main

import "github.com/derekparker/delve/service/rpc2"

const addr = "localhost:41222" // d:4 l:12 v:22

func pointerStruct() {
    client := rpc2.NewClient(addr)
    bp, _ := client.GetBreakpoint(-1)

    bp.
}
```
byte offset: `210`
cmd: `gocode --in ./delve.go autocomplete 210`