### PR TITLE
import: Support gb mode in candidates of package import

### DIFF
--- a/autocompletecontext.go
+++ b/autocompletecontext.go
@@ -229,12 +229,10 @@ func (c *auto_complete_context) get_candidates_from_decl(cc cursor_context, clas
 }
 
 func (c *auto_complete_context) get_import_candidates(partial string, b *out_buffers) {
-	pkgdir := fmt.Sprintf("%s_%s", g_daemon.context.GOOS, g_daemon.context.GOARCH)
-	srcdirs := g_daemon.context.SrcDirs()
-	for _, srcpath := range srcdirs {
+	pkgdirs := g_daemon.context.pkg_dirs()
+	for _, pkgdir := range pkgdirs {
 		// convert srcpath to pkgpath and get candidates
-		pkgpath := filepath.Join(filepath.Dir(srcpath), "pkg", pkgdir)
-		get_import_candidates_dir(pkgpath, filepath.FromSlash(partial), b)
+		get_import_candidates_dir(pkgdir, filepath.FromSlash(partial), b)
 	}
 }
 

--- a/utils.go
+++ b/utils.go
@@ -70,6 +70,11 @@ func file_exists(filename string) bool {
 	return true
 }
 
+func is_dir(path string) bool {
+	fi, err := os.Stat(path)
+	return err == nil && fi.IsDir()
+}
+
 func char_to_byte_offset(s []byte, offset_c int) (offset_b int) {
 	for offset_b = 0; offset_c > 0 && offset_b < len(s); offset_b++ {
 		if utf8.RuneStart(s[offset_b]) {


### PR DESCRIPTION
Support gb specific `pkg` directory path for `get_import_candidates` function.
All tests passes in the my local environments.

I was added new `pkg_dirs` method to `package_lookup_context`. That is imitation of `build.Default.SrcDirs` but return the list of `pkg` path instead of `src` path.
And ignore of lookup the `GOPATH` without `go` mode.
`gopath` function was carried from `build` package.
@nsf What do you thing?

Note that currently not supported `bzl` mode because I'm never used `bazel`.
So, I don't know correct `bazel`'s directory structure.
@linuxerwang If this pull request is accepted, Could you advise me? or Could you send the additional pull request?