### PR TITLE
Exit and print error message for unknown arguments

### DIFF
--- a/client.go
+++ b/client.go
@@ -50,6 +50,9 @@ func do_client() int {
 			cmd_drop_cache(client)
 		case "set":
 			cmd_set(client)
+		default:
+			fmt.Printf("unknown argument: %q. Try running gocode --help\n", flag.Arg(0))
+			return 1
 		}
 	}
 	return 0


### PR DESCRIPTION
Previous behavior was to simply do nothing if an unknown argument was provided. It is more helpful to report an error so users know something is wrong.