### PR TITLE
backport of golang.org/x/tools/9deed8c

### DIFF
--- a/package_bin.go
+++ b/package_bin.go
@@ -116,10 +116,10 @@ func (p *gc_bin_parser) parse_export(callback func(string, ast.Decl)) {
 
 	// read version specific flags - extend as necessary
 	switch p.version {
-	// case 2:
+	// case 3:
 	// 	...
 	//	fallthrough
-	case 1:
+	case 2, 1:
 		p.debugFormat = p.rawStringln(p.rawByte()) == "debug"
 		p.trackAllTypes = p.int() != 0
 		p.posInfoFormat = p.int() != 0


### PR DESCRIPTION
backport of https://github.com/golang/tools/commit/9deed8c6c1c89e0b6d68d727f215de8e851d1064

I have tested 1.6 and devel +f8555ea. It seems have backward compatible.