### PR TITLE
"context" is imported on golang 1.6

### DIFF
--- a/pre_go17.go
+++ b/pre_go17.go
@@ -1,0 +1,7 @@
+// +build !go1.7
+
+package main
+
+func init() {
+	knownPackageIdents["context"] = "golang.org/x/net/context"
+}


### PR DESCRIPTION
[cursorcontext.go](https://github.com/nsf/gocode/blob/46e8fd2234a86934e3e8496c7405984ff7b18df5/cursorcontext.go#L435) contains ```"context": "context",``` but context package does not exist in go 1.6

