### PR TITLE
package_bin: backport of golang.org/x/tools/6d7cee0

### DIFF
--- a/package_bin.go
+++ b/package_bin.go
@@ -111,10 +111,17 @@ func (p *gc_bin_parser) parse_export(callback func(string, ast.Decl)) {
 
 	// read version specific flags - extend as necessary
 	switch p.version {
-	// case 3:
+	// case 4:
 	// 	...
 	//	fallthrough
-	case 2, 1:
+	case 3, 2, 1:
+		// Support for Go 1.8 type aliases will be added very
+		// soon (Oct 2016).  In the meantime, we make a
+		// best-effort attempt to read v3 export data, failing
+		// if we encounter a type alias.  This allows the
+		// automated builders to make progress since
+		// type aliases are not yet used in practice.
+		// TODO(gri): add support for type aliases.
 		p.debugFormat = p.rawStringln(p.rawByte()) == "debug"
 		p.trackAllTypes = p.int() != 0
 		p.posInfoFormat = p.int() != 0


### PR DESCRIPTION
backport of https://github.com/golang/tools/commit/6d7cee0134e889eb7e1f17662ea1881d5a6ffb42

---

I have tested `_testing/all.bash` on 1.7.3 and devel +807a7ebd51. It seems have backward compatible.

Note that go devel will fail on `test.0019` because [`zlib.HuffmanOnly`](https://tip.golang.org/pkg/compress/zlib/#pkg-constants) constant has been added.