### PR TITLE
[WIP] package_bin: support type alias

### DIFF
--- a/decl.go
+++ b/decl.go
@@ -1301,6 +1301,11 @@ func (f *decl_pack) value_index(i int) (v ast.Expr, vi int) {
 
 func (f *decl_pack) type_value_index(i int) (ast.Expr, ast.Expr, int) {
 	if f.typ != nil {
+		// If there is a type and have f.values, it's type alias decl.
+		// Return the both of type and first value.
+		if len(f.values) == 1 {
+			return f.typ, f.values[0], -1
+		}
 		// If there is a type, we don't care about value, just return the type
 		// and zero value.
 		return f.typ, nil, -1

--- a/declcache.go
+++ b/declcache.go
@@ -125,6 +125,10 @@ func append_to_top_decls(decls map[string]*decl, decl ast.Decl, scope *scope) {
 			// Replace the typ to underlying types ast.Expr.
 			if id, ok := typ.(*ast.Ident); ok && id.Obj != nil {
 				if t, ok := id.Obj.Decl.(*ast.TypeSpec); ok {
+					if d, ok := decls[t.Name.Name]; ok {
+						scope.typealias[name.Name] = d
+					}
+
 					typ = t.Type
 				}
 			}
@@ -138,6 +142,11 @@ func append_to_top_decls(decls map[string]*decl, decl ast.Decl, scope *scope) {
 			if methodof != "" {
 				decl, ok := decls[methodof]
 				if ok {
+					if d, ok := scope.typealias[methodof]; ok {
+						for _, d := range d.children {
+							decl.add_child(d)
+						}
+					}
 					decl.add_child(d)
 				} else {
 					decl = new_decl(methodof, decl_methods_stub, scope)

--- a/declcache.go
+++ b/declcache.go
@@ -121,6 +121,14 @@ func append_to_top_decls(decls map[string]*decl, decl ast.Decl, scope *scope) {
 		for i, name := range data.names {
 			typ, v, vi := data.type_value_index(i)
 
+			// If typ is *ast.Ident, it holds the underlying type of type alias.
+			// Replace the typ to underlying types ast.Expr.
+			if id, ok := typ.(*ast.Ident); ok && id.Obj != nil {
+				if t, ok := id.Obj.Decl.(*ast.TypeSpec); ok {
+					typ = t.Type
+				}
+			}
+
 			d := new_decl_full(name.Name, class, 0, typ, v, vi, scope)
 			if d == nil {
 				return

--- a/package_bin.go
+++ b/package_bin.go
@@ -190,12 +190,6 @@ func (p *gc_bin_parser) pkg() string {
 }
 
 func (p *gc_bin_parser) obj(tag int) {
-	var aliasName string
-	if tag == aliasTag {
-		aliasName = p.string()
-		tag = p.tagOrIndex()
-	}
-
 	switch tag {
 	case constTag:
 		p.pos()
@@ -212,6 +206,7 @@ func (p *gc_bin_parser) obj(tag int) {
 				},
 			},
 		})
+
 	case typeTag:
 		_ = p.typ("")
 
@@ -228,6 +223,7 @@ func (p *gc_bin_parser) obj(tag int) {
 				},
 			},
 		})
+
 	case funcTag:
 		p.pos()
 		pkg, name := p.qualifiedName()
@@ -238,22 +234,23 @@ func (p *gc_bin_parser) obj(tag int) {
 			Type: &ast.FuncType{Params: params, Results: results},
 		})
 
-	default:
-		panic(fmt.Sprintf("unexpected object tag %d", tag))
-	}
-
-	if aliasName != "" {
-		pkg, _ := p.qualifiedName()
-		typ := p.typ("")
+	case aliasTag:
+		p.pos()
+		aliasName := p.string()
+		pkg, name := p.qualifiedName()
+		obj := p.typ(name)
 		p.callback(pkg, &ast.GenDecl{
 			Tok: token.TYPE,
 			Specs: []ast.Spec{
 				&ast.TypeSpec{
 					Name: ast.NewIdent(aliasName),
-					Type: typ,
+					Type: obj,
 				},
 			},
 		})
+
+	default:
+		panic(fmt.Sprintf("unexpected object tag %d", tag))
 	}
 }
 

--- a/package_bin.go
+++ b/package_bin.go
@@ -236,15 +236,18 @@ func (p *gc_bin_parser) obj(tag int) {
 
 	case aliasTag:
 		p.pos()
-		aliasName := p.string()
+		name := p.string()
+		var orig ast.Expr
 		pkg, name := p.qualifiedName()
-		obj := p.typ(name)
+		if pkg != "" {
+			orig = p.typ(name)
+		}
 		p.callback(pkg, &ast.GenDecl{
 			Tok: token.TYPE,
 			Specs: []ast.Spec{
 				&ast.TypeSpec{
-					Name: ast.NewIdent(aliasName),
-					Type: obj,
+					Name: ast.NewIdent(name),
+					Type: orig,
 				},
 			},
 		})
@@ -277,7 +280,9 @@ func (p *gc_bin_parser) pos() {
 
 func (p *gc_bin_parser) qualifiedName() (pkg string, name string) {
 	name = p.string()
-	pkg = p.pkg()
+	if name != "" {
+		pkg = p.pkg()
+	}
 	return pkg, name
 }
 

--- a/scope.go
+++ b/scope.go
@@ -5,14 +5,16 @@ package main
 //-------------------------------------------------------------------------
 
 type scope struct {
-	parent   *scope // nil for universe scope
-	entities map[string]*decl
+	parent    *scope // nil for universe scope
+	entities  map[string]*decl
+	typealias map[string]*decl
 }
 
 func new_scope(outer *scope) *scope {
 	s := new(scope)
 	s.parent = outer
 	s.entities = make(map[string]*decl)
+	s.typealias = make(map[string]*decl)
 	return s
 }
 


### PR DESCRIPTION
**THIS PULL REQUEST IS WIP. DO NOT MERGE IT YET**

I'll edit this pull request title and comment after finished implements.

---

The golang/go `master` branch has been merged `dev.typealias`.
Backport of golang/go@c47df7a.

Spec:
- https://tip.golang.org/ref/spec#Types
- https://tip.golang.org/ref/spec#Type_declarations

---

- [x] Support `bexport` new binary format
- [x] Do not raise `PANIC`
- [x] Implements type alias completion
  - [x] Inheritance of underlying type completion candidates for type alias
  - ~Should display only candidates for which aliases can be defined when the current cursor position in type alias (if possible)~
- [x] Keep backward compatibility
- [ ] Add new test case for type alias. For now, copied from any of the following
 - [golang/go/test@c47df7a](https://github.com/golang/go/tree/c47df7ae171b1470f8304c6759caf68f3f37ea90/test)
   - [golang/go/test/alias3.dir/a.go](https://github.com/golang/go/blob/c47df7ae171b1470f8304c6759caf68f3f37ea90/test/alias3.dir/a.go)
 - [golang/tools/go/gcimporter15/testdata@a4fe4f6](https://github.com/golang/tools/tree/a4fe4f61402dd1447f89bc8e0ac557ce8d8d2b0d/go/gcimporter15/testdata)
   - [golang/tools/go/gcimporter15/testdata/exports18.go](https://github.com/golang/tools/blob/a4fe4f61402dd1447f89bc8e0ac557ce8d8d2b0d/go/gcimporter15/testdata/exports18.go)