### PR TITLE
Fixes gocode panics for Go 1.8.

### DIFF
--- a/package_bin.go
+++ b/package_bin.go
@@ -114,7 +114,7 @@ func (p *gc_bin_parser) parse_export(callback func(string, ast.Decl)) {
 	// case 4:
 	// 	...
 	//	fallthrough
-	case 3, 2, 1:
+	case 4, 3, 2, 1:
 		// Support for Go 1.8 type aliases will be added very
 		// soon (Oct 2016).  In the meantime, we make a
 		// best-effort attempt to read v3 export data, failing


### PR DESCRIPTION
The binary format in 1.8 seems to be compatible with prior versions, I was getting panics such as below before this change:
```
panic: unknown export format version 4 ("version 4")
1(runtime.call32): /one/ws/godevtip/go/src/runtime/asm_amd64.s:514
2(runtime.gopanic): /one/ws/godevtip/go/src/runtime/panic.go:489
3(main.(*gc_bin_parser).parse_export): /one/ws/godevtip/src/github.com/nsf/gocode/package_bin.go:131
4(main.(*package_file_cache).process_package_data): /one/ws/godevtip/src/github.com/nsf/gocode/package.go:141
5(main.(*package_file_cache).update_cache): /one/ws/godevtip/src/github.com/nsf/gocode/package.go:90
6(main.update_packages.func1): /one/ws/godevtip/src/github.com/nsf/gocode/autocompletecontext.go:381
7(runtime.goexit): /one/ws/godevtip/go/src/runtime/asm_amd64.s:2197
```

Now everything seems to work fine- if nothing else it can serve as a band-aid for anyone else having issues until a maintainer implements a proper fix.
