### PR TITLE
test/0019: add HuffmanOnly constants for zlib

### DIFF
--- a/_testing/test.0019/out.expected
+++ b/_testing/test.0019/out.expected
@@ -1,7 +1,8 @@
-Found 14 candidates:
+Found 15 candidates:
   const BestCompression 
   const BestSpeed 
   const DefaultCompression 
+  const HuffmanOnly 
   const NoCompression 
   func NewReader(r io.Reader) (io.ReadCloser, error)
   func NewReaderDict(r io.Reader, dict []byte) (io.ReadCloser, error)


### PR DESCRIPTION
Go has been released 1.8.
Added `HuffmanOnly` to `zlib` stdlib package.
- https://github.com/golang/go/blob/go1.8/api/go1.8.txt#L3-L4