### PR TITLE
typealias: add go1.8.typealias build tag for dev.typealias branch

### DIFF
--- a/type_alias_build_hack_18.go
+++ b/type_alias_build_hack_18.go
@@ -1,4 +1,4 @@
-// +build !go1.9
+// +build !go1.9 !go1.8.typealias
 
 package main
 

--- a/type_alias_build_hack_19.go
+++ b/type_alias_build_hack_19.go
@@ -1,4 +1,4 @@
-// +build go1.9
+// +build go1.9 go1.8.typealias
 
 package main
 


### PR DESCRIPTION
Add `go1.8.typealias` build tag for dev.typealias branch.

addressed https://go-review.googlesource.com/c/37510/