### PR TITLE
List import paths for packages vendored only for the current package

### DIFF
--- a/declcache.go
+++ b/declcache.go
@@ -453,9 +453,10 @@ func (ctxt *package_lookup_context) gopath() []string {
 	return all
 }
 
-func (ctxt *package_lookup_context) pkg_dirs() []string {
+func (ctxt *package_lookup_context) pkg_dirs() (string, []string) {
 	pkgdir := fmt.Sprintf("%s_%s", ctxt.GOOS, ctxt.GOARCH)
 
+	var currentPackagePath string
 	var all []string
 	if ctxt.GOROOT != "" {
 		dir := filepath.Join(ctxt.GOROOT, "pkg", pkgdir)
@@ -466,6 +467,7 @@ func (ctxt *package_lookup_context) pkg_dirs() []string {
 
 	switch g_config.PackageLookupMode {
 	case "go":
+		currentPackagePath = ctxt.CurrentPackagePath
 		for _, p := range ctxt.gopath() {
 			dir := filepath.Join(p, "pkg", pkgdir)
 			if is_dir(dir) {
@@ -483,7 +485,7 @@ func (ctxt *package_lookup_context) pkg_dirs() []string {
 	case "bzl":
 		// TODO: Support bazel mode
 	}
-	return all
+	return currentPackagePath, all
 }
 
 type decl_cache struct {

--- a/utils.go
+++ b/utils.go
@@ -153,15 +153,24 @@ func find_gb_project_root(path string) (string, error) {
 
 // vendorlessImportPath returns the devendorized version of the provided import path.
 // e.g. "foo/bar/vendor/a/b" => "a/b"
-func vendorlessImportPath(ipath string) string {
+func vendorlessImportPath(ipath string, currentPackagePath string) (string, bool) {
+	split := strings.Split(ipath, "vendor/")
+	// no vendor in path
+	if len(split) == 1 {
+		return ipath, true
+	}
+	// this import path does not belong to the current package
+	if currentPackagePath != "" && !strings.Contains(currentPackagePath, split[0]) {
+		return "", false
+	}
 	// Devendorize for use in import statement.
 	if i := strings.LastIndex(ipath, "/vendor/"); i >= 0 {
-		return ipath[i+len("/vendor/"):]
+		return ipath[i+len("/vendor/"):], true
 	}
 	if strings.HasPrefix(ipath, "vendor/") {
-		return ipath[len("vendor/"):]
+		return ipath[len("vendor/"):], true
 	}
-	return ipath
+	return ipath, true
 }
 
 //-------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #381 (especially https://github.com/nsf/gocode/issues/381#issuecomment-254030639)

Filters out import paths vendored by other packages.

`currentPackagePath` addresses only *native* go vendoring.

I'm not experienced with `gb` so I didn't test it.

@nsf if you could test it with `gb` and give some feedback I would highly appreciate.