### PR TITLE
decl/type_dealias: add handle the nil of decl

### DIFF
--- a/decl.go
+++ b/decl.go
@@ -989,7 +989,7 @@ func (d *decl) type_dealias() *decl {
 	defer d.clear_visited()
 
 	dd := type_to_decl(d.typ, d.scope)
-	if dd.is_alias() {
+	if dd != nil && dd.is_alias() {
 		return dd.type_dealias()
 	}
 	return dd


### PR DESCRIPTION
Add handle `dd` is `nil`, such as typealias `C` type.
If `dd` is `nil`, just return the `dd`.

The below go code is valid(can compile), and display the `1`. but now gocode will `PANIC` because `d.typ` is  `*ast.SelectorExpr{X: C Sel: int}` actually `C` type (maybe, I think)
However, this change still can't get the `String` method(Is it possible?). Workaround.

`gocode -in ./path/to/foo.go autocomplete 222`
```go
package main

import "C"
import (
	"fmt"
)

type Foo = C.int

func (f Foo) String() string {
	switch f {
	case 0:
		return "0"
	case 1:
		return "1"
	default:
		return ""
	}
}

func main() {
	var s = Foo(1)
	fmt.Println(s.#String()) // this line
}
```