### PR TITLE
package_bin: backport interface embedding support

### DIFF
--- a/_testing/test.0057/out.expected
+++ b/_testing/test.0057/out.expected
@@ -1,0 +1,3 @@
+Found 2 candidates:
+  func Read(p []byte) (n int, err error)
+  func Write(p []byte) (n int, err error)

--- a/_testing/test.0057/test.go.in
+++ b/_testing/test.0057/test.go.in
@@ -1,0 +1,7 @@
+package main
+
+import "io"
+
+func main() {
+	io.ReadWriter.
+}


### PR DESCRIPTION
Support interface embedding. Also, add the test case. Backport of golang/tools@b08393c.

Current Go `tip` will reach `p.int() != 0` becasue has been exported interface embedding information on golang/go@ee272bb.
We don't have `type.Named` and `type.Interface.embeddeds` method, So I fixed the code to corresponds to the gocode. just `append` the `*ast.Field`.

And add test case from the [golang/tools@b08393c#diff](https://github.com/golang/tools/commit/b08393ce6db03dc9c3b8a34f5cf0c7994d59a44e#diff-0d3ef5ad786d1fa211faa2fbbe902d23R252). That is if we have not merged this fix, will `PANIC` with tip.(but another test also fail)
I tested tip and go1.8. But I don't know it is correct fix, and there is no guarantee that keep backward compatibility. Please code review if you have time.