### PR TITLE
Make company-go an interactive Emacs function

### DIFF
--- a/emacs-company/company-go.el
+++ b/emacs-company/company-go.el
@@ -195,7 +195,9 @@ triggers a completion immediately."
 
 ;;;###autoload
 (defun company-go (command &optional arg &rest ignored)
+  (interactive (list 'interactive))
   (case command
+    (interactive (company-begin-backend 'company-go))
     (prefix (and (derived-mode-p 'go-mode)
                  (not (company-in-string-or-comment))
                  (not (company-go--in-num-literal-p))


### PR DESCRIPTION
The convention for company backends is to make them interactive, so
users can manually invoke them. This is particularly useful when
setting up a backend, to allow the user to explicitly test their
setup.