### PR TITLE
force symlink creation

### DIFF
--- a/nvim/symlink.sh
+++ b/nvim/symlink.sh
@@ -3,5 +3,5 @@ cd "${0%/*}"
 ROOTDIR=`pwd`
 mkdir -p "$HOME/.config/nvim/autoload"
 mkdir -p "$HOME/.config/nvim/ftplugin/go"
-ln -s "$ROOTDIR/autoload/gocomplete.vim" "$HOME/.config/nvim/autoload/"
-ln -s "$ROOTDIR/ftplugin/go/gocomplete.vim" "$HOME/.config/nvim/ftplugin/go/"
+ln -fs "$ROOTDIR/autoload/gocomplete.vim" "$HOME/.config/nvim/autoload/"
+ln -fs "$ROOTDIR/ftplugin/go/gocomplete.vim" "$HOME/.config/nvim/ftplugin/go/"

--- a/vim/symlink.sh
+++ b/vim/symlink.sh
@@ -3,5 +3,5 @@ cd "${0%/*}"
 ROOTDIR=`pwd`
 mkdir -p "$HOME/.vim/autoload"
 mkdir -p "$HOME/.vim/ftplugin/go"
-ln -s "$ROOTDIR/autoload/gocomplete.vim" "$HOME/.vim/autoload/"
-ln -s "$ROOTDIR/ftplugin/go/gocomplete.vim" "$HOME/.vim/ftplugin/go/"
+ln -fs "$ROOTDIR/autoload/gocomplete.vim" "$HOME/.vim/autoload/"
+ln -fs "$ROOTDIR/ftplugin/go/gocomplete.vim" "$HOME/.vim/ftplugin/go/"


### PR DESCRIPTION
vim-plug's `:PlugInstall!` runs the callbacks each time.
if the symlinks exist, the call failed.