### PR TITLE
Let user specify path to gocode bin

### DIFF
--- a/emacs/go-autocomplete.el
+++ b/emacs/go-autocomplete.el
@@ -51,6 +51,11 @@
   :type 'boolean
   :group 'go-autocomplete)
 
+(defcustom ac-go-gocode-bin "gocode"
+  "Overwrite path to gocode binary"
+  :type 'string
+  :group 'go-autocomplete)
+
 ;; Close gocode daemon at exit unless it was already running
 (eval-after-load "go-mode"
   '(progn
@@ -95,7 +100,7 @@
         (progn
           (call-process-region (point-min)
                                (point-max)
-                               "gocode"
+                               ac-go-gocode-bin
                                nil
                                temp-buffer
                                nil


### PR DESCRIPTION
Emacs package go-autocomplete.el:
Add option to let users specify the path (and/or name)
of the gocode binary