### PR TITLE
Pass through package names, use it for godoc in emacs-company

### DIFF
--- a/autocompletecontext.go
+++ b/autocompletecontext.go
@@ -22,9 +22,10 @@ import (
 
 // fields must be exported for RPC
 type candidate struct {
-	Name  string
-	Type  string
-	Class decl_class
+	Name    string
+	Type    string
+	Class   decl_class
+	Package string
 }
 
 type out_buffers struct {
@@ -65,7 +66,7 @@ func (b *out_buffers) Swap(i, j int) {
 	b.candidates[i], b.candidates[j] = b.candidates[j], b.candidates[i]
 }
 
-func (b *out_buffers) append_decl(p, name string, decl *decl, class decl_class) {
+func (b *out_buffers) append_decl(p, name, pkg string, decl *decl, class decl_class) {
 	c1 := !g_config.ProposeBuiltins && decl.scope == g_universe_scope && decl.name != "Error"
 	c2 := class != decl_invalid && decl.class != class
 	c3 := class == decl_invalid && !has_prefix(name, p, b.ignorecase)
@@ -78,14 +79,15 @@ func (b *out_buffers) append_decl(p, name string, decl *decl, class decl_class) 
 
 	decl.pretty_print_type(b.tmpbuf, b.canonical_aliases)
 	b.candidates = append(b.candidates, candidate{
-		Name:  name,
-		Type:  b.tmpbuf.String(),
-		Class: decl.class,
+		Name:    name,
+		Type:    b.tmpbuf.String(),
+		Class:   decl.class,
+		Package: pkg,
 	})
 	b.tmpbuf.Reset()
 }
 
-func (b *out_buffers) append_embedded(p string, decl *decl, class decl_class) {
+func (b *out_buffers) append_embedded(p string, decl *decl, pkg string, class decl_class) {
 	if decl.embedded == nil {
 		return
 	}
@@ -119,10 +121,10 @@ func (b *out_buffers) append_embedded(p string, decl *decl, class decl_class) {
 			if _, has := b.tmpns[c.name]; has {
 				continue
 			}
-			b.append_decl(p, c.name, c, class)
+			b.append_decl(p, c.name, pkg, c, class)
 			b.tmpns[c.name] = true
 		}
-		b.append_embedded(p, typedecl, class)
+		b.append_embedded(p, typedecl, pkg, class)
 	}
 
 	if first_level {
@@ -208,7 +210,11 @@ func (c *auto_complete_context) get_candidates_from_set(set map[string]*decl, pa
 			continue
 		}
 		value.infer_type()
-		b.append_decl(partial, key, value, class)
+		pkgname := ""
+		if pkg, ok := c.pcache[value.name]; ok {
+			pkgname = pkg.import_name
+		}
+		b.append_decl(partial, key, pkgname, value, class)
 	}
 }
 
@@ -246,19 +252,25 @@ func (c *auto_complete_context) get_candidates_from_decl(cc cursor_context, clas
 				continue
 			}
 		}
-		b.append_decl(cc.partial, decl.name, decl, class)
+		pkgname := ""
+		if pkg, ok := c.pcache[decl.scope.pkgname]; ok {
+			pkgname = pkg.import_name
+		}
+		b.append_decl(cc.partial, decl.name, pkgname, decl, class)
 	}
 	// propose all children of an underlying struct/interface type
 	adecl := advance_to_struct_or_interface(cc.decl)
 	if adecl != nil && adecl != cc.decl {
 		for _, decl := range adecl.children {
 			if decl.class == decl_var {
-				b.append_decl(cc.partial, decl.name, decl, class)
+				pkgname := c.pcache[decl.name].import_name
+				b.append_decl(cc.partial, decl.name, pkgname, decl, class)
 			}
 		}
 	}
 	// propose all children of its embedded types
-	b.append_embedded(cc.partial, cc.decl, class)
+	pkgname := c.pcache[cc.decl.name].import_name
+	b.append_embedded(cc.partial, cc.decl, pkgname, class)
 }
 
 func (c *auto_complete_context) get_import_candidates(partial string, b *out_buffers) {

--- a/autocompletecontext.go
+++ b/autocompletecontext.go
@@ -43,7 +43,7 @@ func new_out_buffers(ctx *auto_complete_context) *out_buffers {
 	b.ctx = ctx
 	b.canonical_aliases = make(map[string]string)
 	for _, imp := range b.ctx.current.packages {
-		b.canonical_aliases[imp.path] = imp.alias
+		b.canonical_aliases[imp.abspath] = imp.alias
 	}
 	return b
 }
@@ -482,7 +482,7 @@ func merge_decls(filescope *scope, pkg *scope, decls map[string]*decl) {
 
 func merge_decls_from_packages(pkgscope *scope, pkgs []package_import, pcache package_cache) {
 	for _, p := range pkgs {
-		path, alias := p.path, p.alias
+		path, alias := p.abspath, p.alias
 		if alias != "." {
 			continue
 		}
@@ -500,7 +500,7 @@ func merge_decls_from_packages(pkgscope *scope, pkgs []package_import, pcache pa
 
 func fixup_packages(filescope *scope, pkgs []package_import, pcache package_cache) {
 	for _, p := range pkgs {
-		path, alias := p.path, p.alias
+		path, alias := p.abspath, p.alias
 		if alias == "" {
 			alias = pcache[path].defalias
 		}

--- a/cursorcontext.go
+++ b/cursorcontext.go
@@ -413,7 +413,7 @@ func resolveKnownPackageIdent(ident string, filename string, context *package_lo
 		return nil
 	}
 
-	p := new_package_file_cache(path)
+	p := new_package_file_cache(path, path)
 	p.update_cache()
 	return p.main
 }

--- a/declcache.go
+++ b/declcache.go
@@ -19,8 +19,9 @@ import (
 //-------------------------------------------------------------------------
 
 type package_import struct {
-	alias string
-	path  string
+	alias   string
+	abspath string
+	path    string
 }
 
 // Parses import declarations until the first non-import declaration and fills
@@ -32,9 +33,9 @@ func collect_package_imports(filename string, decls []ast.Decl, context *package
 			for _, spec := range gd.Specs {
 				imp := spec.(*ast.ImportSpec)
 				path, alias := path_and_alias(imp)
-				path, ok := abs_path_for_package(filename, path, context)
+				abspath, ok := abs_path_for_package(filename, path, context)
 				if ok && alias != "_" {
-					pi = append(pi, package_import{alias, path})
+					pi = append(pi, package_import{alias, abspath, path})
 				}
 			}
 		} else {

--- a/formatters.go
+++ b/formatters.go
@@ -124,7 +124,7 @@ type csv_formatter struct{}
 
 func (*csv_formatter) write_candidates(candidates []candidate, num int) {
 	for _, c := range candidates {
-		fmt.Printf("%s,,%s,,%s\n", c.Class, c.Name, c.Type)
+		fmt.Printf("%s,,%s,,%s,,%s\n", c.Class, c.Name, c.Type, c.Package)
 	}
 }
 
@@ -145,8 +145,8 @@ func (*json_formatter) write_candidates(candidates []candidate, num int) {
 		if i != 0 {
 			fmt.Printf(", ")
 		}
-		fmt.Printf(`{"class": "%s", "name": "%s", "type": "%s"}`,
-			c.Class, c.Name, c.Type)
+		fmt.Printf(`{"class": "%s", "name": "%s", "type": "%s", "package": "%s"}`,
+			c.Class, c.Name, c.Type, c.Package)
 	}
 	fmt.Print("]]")
 }

--- a/package.go
+++ b/package.go
@@ -219,16 +219,16 @@ func new_package_cache() package_cache {
 // In case if package is not in the cache, it creates one and adds one to the cache.
 func (c package_cache) append_packages(ps map[string]*package_file_cache, pkgs []package_import) {
 	for _, m := range pkgs {
-		if _, ok := ps[m.path]; ok {
+		if _, ok := ps[m.abspath]; ok {
 			continue
 		}
 
-		if mod, ok := c[m.path]; ok {
-			ps[m.path] = mod
+		if mod, ok := c[m.abspath]; ok {
+			ps[m.abspath] = mod
 		} else {
-			mod = new_package_file_cache(m.path)
-			ps[m.path] = mod
-			c[m.path] = mod
+			mod = new_package_file_cache(m.abspath)
+			ps[m.abspath] = mod
+			c[m.abspath] = mod
 		}
 	}
 }

--- a/package.go
+++ b/package.go
@@ -20,18 +20,20 @@ type package_parser interface {
 //-------------------------------------------------------------------------
 
 type package_file_cache struct {
-	name     string // file name
-	mtime    int64
-	defalias string
+	name        string // file name
+	import_name string
+	mtime       int64
+	defalias    string
 
 	scope  *scope
 	main   *decl // package declaration
 	others map[string]*decl
 }
 
-func new_package_file_cache(name string) *package_file_cache {
+func new_package_file_cache(absname, name string) *package_file_cache {
 	m := new(package_file_cache)
-	m.name = name
+	m.name = absname
+	m.import_name = name
 	m.mtime = 0
 	m.defalias = ""
 	return m
@@ -92,7 +94,7 @@ func (m *package_file_cache) update_cache() {
 }
 
 func (m *package_file_cache) process_package_data(data []byte) {
-	m.scope = new_scope(g_universe_scope)
+	m.scope = new_named_scope(g_universe_scope, m.name)
 
 	// find import section
 	i := bytes.Index(data, []byte{'\n', '$', '$'})
@@ -226,7 +228,7 @@ func (c package_cache) append_packages(ps map[string]*package_file_cache, pkgs [
 		if mod, ok := c[m.abspath]; ok {
 			ps[m.abspath] = mod
 		} else {
-			mod = new_package_file_cache(m.abspath)
+			mod = new_package_file_cache(m.abspath, m.path)
 			ps[m.abspath] = mod
 			c[m.abspath] = mod
 		}

--- a/scope.go
+++ b/scope.go
@@ -5,12 +5,23 @@ package main
 //-------------------------------------------------------------------------
 
 type scope struct {
+	// the package name that this scope resides in
+	pkgname  string
 	parent   *scope // nil for universe scope
 	entities map[string]*decl
 }
 
+func new_named_scope(outer *scope, name string) *scope {
+	s := new_scope(outer)
+	s.pkgname = name
+	return s
+}
+
 func new_scope(outer *scope) *scope {
 	s := new(scope)
+	if outer != nil {
+		s.pkgname = outer.pkgname
+	}
 	s.parent = outer
 	s.entities = make(map[string]*decl)
 	return s

--- a/server.go
+++ b/server.go
@@ -137,7 +137,7 @@ func server_auto_complete(file []byte, filename string, cursor int, context_pack
 		if err := recover(); err != nil {
 			print_backtrace(err)
 			c = []candidate{
-				{"PANIC", "PANIC", decl_invalid},
+				{"PANIC", "PANIC", decl_invalid, "panic"},
 			}
 
 			// drop cache


### PR DESCRIPTION
This pull request adds a few fields to the `decl`, `candidate`, `scope` and `package_import` structures, populated with the import path for the package that each symbol is defined in. This makes it possible to later (in emacs's `company-go` package) automatically perform a documentation lookup for each symbol being completed.

I believe this PR addresses #415 (it builds on the sample code that @nikclayton kindly provided in this issue). Here's a screenshot of how it looks in practice:

![screen shot 2017-08-15 at 10 57 38 pm](https://user-images.githubusercontent.com/11864/29349174-2e7477f4-820d-11e7-9c2e-8c02139604ae.png)

I hope you find this change acceptable - I ran the tests, and the same tests fail as on master (3); hope that's OK too! And of course, please let me know if there is anything you would like to see improved. I'll be happy to fix this if it means I can get automatic docs in emacs (-: