### PR TITLE
fix vendor import get ignored

### DIFF
--- a/autocompletecontext.go
+++ b/autocompletecontext.go
@@ -284,7 +284,6 @@ func (c *auto_complete_context) get_candidates_from_decl(cc cursor_context, clas
 
 func (c *auto_complete_context) get_import_candidates(partial string, b *out_buffers) {
 	currentPackagePath, pkgdirs := g_daemon.context.pkg_dirs()
-	fmt.Println(pkgdirs)
 	resultSet := map[string]struct{}{}
 	for _, pkgdir := range pkgdirs {
 		// convert srcpath to pkgpath and get candidates

--- a/declcache.go
+++ b/declcache.go
@@ -478,6 +478,10 @@ func (ctxt *package_lookup_context) pkg_dirs() (string, []string) {
 			if is_dir(dir) {
 				all = append(all, dir)
 			}
+			dir = filepath.Join(dir, currentPackagePath, "vendor")
+			if is_dir(dir) {
+				all = append(all, dir)
+			}
 		}
 	case "gb":
 		if ctxt.GBProjectRoot != "" {


### PR DESCRIPTION
I'm not sure if it should be fixed this way, but the issue is probably real. Gocode handles vendor package content correctly (i.e. the exported fields of a vendor package are all shown), but it seems to ignore vendor import. To reproduce the issue:
```
$GOPATH/src/github.com/a/b/
|---main.go
|---vendor/github.com/c/d/
    |---p.go
```
Where in `main.go` (`#` denotes the cursor position)
```
package main

import "github.com/c#"
```
The option `github.com/c/d` does not present in the candidates.