### PR TITLE
Remove unreachable code so we can pass go vet

### DIFF
--- a/autocompletecontext.go
+++ b/autocompletecontext.go
@@ -659,7 +659,6 @@ func check_type_expr(e ast.Expr) bool {
 	default:
 		return true
 	}
-	return true
 }
 
 //-------------------------------------------------------------------------

--- a/cursorcontext.go
+++ b/cursorcontext.go
@@ -35,10 +35,8 @@ type token_item struct {
 func (i token_item) literal() string {
 	if i.tok.IsLiteral() {
 		return i.lit
-	} else {
-		return i.tok.String()
 	}
-	return ""
+	return i.tok.String()
 }
 
 func new_token_iterator(src []byte, cursor int) token_iterator {

--- a/decl.go
+++ b/decl.go
@@ -118,7 +118,6 @@ func ast_decl_type(d ast.Decl) ast.Expr {
 		return t.Type
 	}
 	panic("unreachable")
-	return nil
 }
 
 func ast_decl_flags(d ast.Decl) decl_flags {


### PR DESCRIPTION
This makes gocode pass `go vet ./...`.