### PR TITLE
Fix failure in test 0055 introduced by: d7aee8965

### DIFF
--- a/decl.go
+++ b/decl.go
@@ -67,6 +67,8 @@ const (
 
 	// for preventing infinite recursions and loops in type inference code
 	decl_visited
+
+	decl_visited_find_child_and_in_embedded
 )
 
 //-------------------------------------------------------------------------
@@ -391,12 +393,24 @@ func (d *decl) is_visited() bool {
 	return d.flags&decl_visited != 0
 }
 
+func (d *decl) is_visited_find_child_and_in_embedded() bool {
+	return d.flags&decl_visited_find_child_and_in_embedded != 0
+}
+
 func (d *decl) set_visited() {
 	d.flags |= decl_visited
 }
 
+func (d *decl) set_visited_find_child_and_in_embedded() {
+	d.flags |= decl_visited_find_child_and_in_embedded
+}
+
 func (d *decl) clear_visited() {
 	d.flags &^= decl_visited
+}
+
+func (d *decl) clear_visited_find_child_and_in_embedded() {
+	d.flags &^= decl_visited_find_child_and_in_embedded
 }
 
 func (d *decl) expand_or_replace(other *decl) {
@@ -1036,11 +1050,11 @@ func (d *decl) find_child_and_in_embedded(name string) *decl {
 		return nil
 	}
 
-	if d.is_visited() {
+	if d.is_visited_find_child_and_in_embedded() {
 		return nil
 	}
-	d.set_visited()
-	defer d.clear_visited()
+	d.set_visited_find_child_and_in_embedded()
+	defer d.clear_visited_find_child_and_in_embedded()
 
 	c := d.find_child(name)
 	if c == nil {


### PR DESCRIPTION
Commit d7aee8965 broke test 0055 as setting the `decl_visited` in [decl.find_child_and_in_embedded()](https://github.com/charlievieth/gocode/blob/fix-test-55-failure/decl.go#L1048) prevents other type inference methods from running.  This commit introduces a new decl_flags constant, [decl_visited_find_child_and_in_embedded](https://github.com/charlievieth/gocode/blob/fix-test-55-failure/decl.go#L71), for [decl. find_child_and_in_embedded()](https://github.com/charlievieth/gocode/blob/fix-test-55-failure/decl.go#L1048-L1057) so other type inference methods may still run while guarding against infinite recursion.

Also, the name of the new constant [decl_visited_find_child_and_in_embedded](https://github.com/charlievieth/gocode/blob/fix-test-55-failure/decl.go#L71) and the associated decl methods are pretty long.  Please feel free to change it or offer suggestions for a better name and I'll update the PR.