### PR TITLE
[company-go]: Passes a `-source` flag to gocode by default

### DIFF
--- a/emacs-company/company-go.el
+++ b/emacs-company/company-go.el
@@ -71,7 +71,8 @@ symbol is preceded by a \".\", ignoring `company-minimum-prefix-length'."
 (defun company-go--invoke-autocomplete ()
   (let ((code-buffer (current-buffer))
         (gocode-args (append company-go-gocode-args
-                             (list "-f=csv-with-package"
+                             (list "-source"
+                                   "-f=csv"
                                    "autocomplete"
                                    (or (buffer-file-name) "")
                                    (concat "c" (int-to-string (- (point) 1)))))))


### PR DESCRIPTION
I also noticed that the forked gocode does not support `csv-with-package`, and so I changed this at the same time. I am increasingly unsure if this change should be merged, or if the version in MELPA should be repointed to the forked company-go.

Fixes #529